### PR TITLE
fix: sanitize issue_id to prevent path traversal

### DIFF
--- a/scripts/emit_issue.py
+++ b/scripts/emit_issue.py
@@ -1,19 +1,35 @@
-import hashlib, json, pathlib, datetime
+import datetime
+import hashlib
+import json
+import pathlib
+import re
+from typing import Any, Dict
 
-ROOT = pathlib.Path('issuesdb/issues')
+ROOT = pathlib.Path('issuesdb/issues').resolve()
+ISSUE_ID_PATTERN = re.compile(r'^[a-f0-9]{40}$')
+
 
 def sha1(s: str) -> str:
     return hashlib.sha1(s.encode('utf-8')).hexdigest()
 
-def write_issue(doc: dict):
+
+def write_issue(doc: Dict[str, Any]) -> pathlib.Path:
+    """Write issue document to canonical JSON file."""
     assert 'issue_id' in doc and 'source' in doc and 'title' in doc, 'minimum fields missing'
-    src   = doc['source']
-    lang  = (doc.get('language') or 'unknown').lower()
-    out   = ROOT / src / lang
+    issue_id = doc['issue_id']
+    if not ISSUE_ID_PATTERN.fullmatch(issue_id):
+        raise ValueError('issue_id must be a 40-character hexadecimal string')
+    src = doc['source']
+    lang = (doc.get('language') or 'unknown').lower()
+    out = (ROOT / src / lang).resolve()
     out.mkdir(parents=True, exist_ok=True)
     if 'updated_at' not in doc:
         doc['updated_at'] = datetime.datetime.utcnow().replace(microsecond=0).isoformat() + 'Z'
-    path = out / f"{doc['issue_id']}.json"
+    path = (out / f'{issue_id}.json').resolve()
+    try:
+        path.relative_to(out)
+    except ValueError as exc:
+        raise ValueError('resolved path escapes target directory') from exc
     with path.open('w', encoding='utf-8') as f:
         json.dump(doc, f, ensure_ascii=False, indent=2, sort_keys=True)
     return path

--- a/tests/test_emit_issue.py
+++ b/tests/test_emit_issue.py
@@ -1,0 +1,34 @@
+import json
+import pathlib
+import pytest
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / 'scripts'))
+import emit_issue
+
+
+def test_write_issue_valid(monkeypatch, tmp_path):
+    monkeypatch.setattr(emit_issue, 'ROOT', tmp_path)
+    doc = {
+        'issue_id': 'a' * 40,
+        'source': 'src',
+        'title': 'ok',
+    }
+    path = emit_issue.write_issue(doc)
+    expected = tmp_path / 'src' / 'unknown' / (doc['issue_id'] + '.json')
+    assert path == expected
+    assert path.exists()
+    data = json.loads(path.read_text('utf-8'))
+    assert data['issue_id'] == doc['issue_id']
+
+
+def test_write_issue_path_traversal(monkeypatch, tmp_path):
+    monkeypatch.setattr(emit_issue, 'ROOT', tmp_path)
+    doc = {
+        'issue_id': '../../../etc/passwd',
+        'source': 'src',
+        'title': 'bad',
+    }
+    with pytest.raises(ValueError):
+        emit_issue.write_issue(doc)
+    assert not list(tmp_path.rglob('passwd'))


### PR DESCRIPTION
## Summary
- validate issue_id format before writing issues
- resolve and bound paths to avoid directory traversal
- add tests covering path traversal attempts

## Testing
- `python -m py_compile scripts/emit_issue.py tests/test_emit_issue.py`
- `pytest -q`
- `python - <<'PY'\nfrom scripts import emit_issue\ntry:\n    emit_issue.write_issue({'issue_id':'../../../etc/passwd','source':'src','title':'x'})\nexcept Exception as e:\n    print(type(e).__name__, e)\nPY`
- `rg -n --ignore-case api_key -g '*.py'; rg -n --ignore-case apikey -g '*.py'; rg -n --ignore-case secret -g '*.py'; rg -n --ignore-case password -g '*.py'; rg -n --ignore-case token -g '*.py'`

------
https://chatgpt.com/codex/tasks/task_e_68b4d284cc508322b9ec389e286efa22