### PR TITLE
feat: reject oversized JSON inputs

### DIFF
--- a/scripts/build_index.py
+++ b/scripts/build_index.py
@@ -1,4 +1,5 @@
 import sqlite3, json, pathlib
+from json_utils import load_json
 
 ROOT = pathlib.Path('issuesdb')
 DB   = ROOT / 'issues.sqlite'
@@ -6,8 +7,7 @@ SQL  = pathlib.Path('issues_index.sql')
 
 def iter_docs():
     for p in (ROOT / 'issues').glob('*/*/*.json'):
-        with p.open('r', encoding='utf-8') as f:
-            yield json.load(f)
+        yield load_json(p)
 
 con = sqlite3.connect(DB)
 cur = con.cursor()

--- a/scripts/chunk_export.py
+++ b/scripts/chunk_export.py
@@ -1,4 +1,5 @@
 import json, pathlib
+from json_utils import load_json
 
 ROOT = pathlib.Path('issuesdb/issues')
 OUTD = pathlib.Path('exports'); OUTD.mkdir(parents=True, exist_ok=True)
@@ -25,8 +26,7 @@ def chunks(text: str, max_chars=MAX_CHARS):
 
 def iter_issues():
     for p in ROOT.glob('*/*/*.json'):
-        with p.open('r', encoding='utf-8') as f:
-            yield json.load(f)
+        yield load_json(p)
 
 with OUTF.open('w', encoding='utf-8') as out:
     for doc in iter_issues():

--- a/scripts/json_utils.py
+++ b/scripts/json_utils.py
@@ -1,0 +1,13 @@
+import json
+from pathlib import Path
+from typing import Any
+
+MAX_JSON_BYTES = 1_000_000
+
+
+def load_json(path: Path) -> Any:
+    size = path.stat().st_size
+    if size > MAX_JSON_BYTES:
+        raise ValueError(f'JSON file {path} exceeds {MAX_JSON_BYTES} bytes (size={size})')
+    with path.open('r', encoding='utf-8') as f:
+        return json.load(f)

--- a/scripts/render_memory_bank.py
+++ b/scripts/render_memory_bank.py
@@ -1,4 +1,5 @@
 import pathlib, json, datetime
+from json_utils import load_json
 
 ROOT = pathlib.Path('.')
 MB   = ROOT / 'memory_bank'
@@ -8,8 +9,7 @@ def count_docs():
     total = 0; by_source = {}; by_lang = {}
     for p in ISS.glob('*/*/*.json'):
         total += 1
-        with p.open('r', encoding='utf-8') as f:
-            doc = json.load(f)
+        doc = load_json(p)
         src = doc['source']; by_source[src] = by_source.get(src,0)+1
         lang = (doc.get('language') or 'unknown').lower()
         by_lang[lang] = by_lang.get(lang,0)+1

--- a/tests/test_json_utils.py
+++ b/tests/test_json_utils.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+import json
+import pytest
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / 'scripts'))
+from json_utils import MAX_JSON_BYTES, load_json
+
+
+def test_load_json_rejects_oversized_file(tmp_path: Path) -> None:
+    big_value = 'x' * MAX_JSON_BYTES
+    path = tmp_path / 'big.json'
+    path.write_text(json.dumps({'data': big_value}), encoding='utf-8')
+    assert path.stat().st_size > MAX_JSON_BYTES
+    with pytest.raises(ValueError):
+        load_json(path)


### PR DESCRIPTION
## Summary
- add `MAX_JSON_BYTES` constant and `load_json` helper to enforce JSON size limit
- guard JSON reads in build_index, chunk_export, and render_memory_bank using new loader
- test oversized JSON files are rejected

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4d971a85883229895bc7abf7bf268