### PR TITLE
feat: enforce JSON size limits for issue writes

### DIFF
--- a/tests/test_emit_issue.py
+++ b/tests/test_emit_issue.py
@@ -56,3 +56,34 @@ def test_write_issues_batch_atomic(monkeypatch, tmp_path):
     with pytest.raises(ValueError):
         emit_issue.write_issues_batch(docs)
     assert not list(tmp_path.rglob('*.json'))
+
+
+def test_write_issue_too_big(monkeypatch, tmp_path):
+    monkeypatch.setattr(emit_issue, 'ROOT', tmp_path)
+    monkeypatch.setattr(emit_issue, 'MAX_JSON_BYTES', 10)
+    doc = {
+        'issue_id': 'a' * 40,
+        'source': 'src',
+        'title': 'ok',
+        'payload': 'x' * 20,
+    }
+    with pytest.raises(ValueError):
+        emit_issue.write_issue(doc)
+    assert not list(tmp_path.rglob('*.json'))
+
+
+def test_write_issues_batch_too_big(monkeypatch, tmp_path):
+    monkeypatch.setattr(emit_issue, 'ROOT', tmp_path)
+    monkeypatch.setattr(emit_issue, 'MAX_JSON_BYTES', 10)
+    docs = [
+        {
+            'issue_id': 'a' * 40,
+            'source': 'src',
+            'title': 'ok',
+            'payload': 'x' * 20,
+        },
+        {'issue_id': 'b' * 40, 'source': 'src', 'title': 'ok'},
+    ]
+    with pytest.raises(ValueError):
+        emit_issue.write_issues_batch(docs)
+    assert not list(tmp_path.rglob('*.json'))


### PR DESCRIPTION
## Summary
- enforce MAX_JSON_BYTES when writing issue documents
- abort batch and single writes exceeding size limit
- test oversized document handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4ddc4fd1083228d6026cae27a8abd