### PR TITLE
feat: add security scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ python scripts/chunk_export.py
 python scripts/render_memory_bank.py
 ```
 
+## Security Scan
+
+Scan the repository for potential secrets, missing input validation, and unsafe SQL usage:
+
+```bash
+python scripts/security_scan.py scripts
+```
+
+The command exits with a non-zero status when issues are found so it can be used in CI workflows.
+
 ## Layout
 ```
 .
@@ -36,5 +46,6 @@ python scripts/render_memory_bank.py
    ├─ emit_issue.py
    ├─ build_index.py
    ├─ chunk_export.py
-   └─ render_memory_bank.py
+   ├─ render_memory_bank.py
+   └─ security_scan.py
 ```

--- a/scripts/security_scan.py
+++ b/scripts/security_scan.py
@@ -1,0 +1,140 @@
+"""Security scanner for Python files.
+
+Scans directories for potential secrets, missing input validation, and
+SQL statements without placeholders.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import logging
+import re
+import sys
+import uuid
+from dataclasses import dataclass
+from math import log2
+from pathlib import Path
+from typing import Iterable, List
+
+logger = logging.getLogger(__name__)
+
+SECRET_PATTERNS = [
+    re.compile(r"api_key\s*=", re.IGNORECASE),
+    re.compile(r"secret\s*=", re.IGNORECASE),
+    re.compile(r"token\s*=", re.IGNORECASE),
+]
+
+HIGH_ENTROPY_THRESHOLD = 4.0
+
+
+@dataclass
+class Finding:
+    path: Path
+    message: str
+
+
+def shannon_entropy(data: str) -> float:
+    probabilities = [float(data.count(c)) / len(data) for c in set(data)]
+    return -sum(p * log2(p) for p in probabilities)
+
+
+def is_high_entropy(value: str) -> bool:
+    return len(value) >= 20 and shannon_entropy(value) > HIGH_ENTROPY_THRESHOLD
+
+
+def detect_secrets(source: str) -> bool:
+    if any(pattern.search(source) for pattern in SECRET_PATTERNS):
+        return True
+    for match in re.finditer(r"['\"]([A-Za-z0-9+/=]{20,})['\"]", source):
+        if is_high_entropy(match.group(1)):
+            return True
+    return False
+
+
+def function_lacks_validation(node: ast.FunctionDef) -> bool:
+    if not any("path" in arg.arg.lower() for arg in node.args.args):
+        return False
+    for child in ast.walk(node):
+        if isinstance(child, ast.Call):
+            func = child.func
+            if isinstance(func, ast.Attribute):
+                if func.attr == "resolve":
+                    return False
+                if isinstance(func.value, ast.Name) and func.value.id == "re":
+                    return False
+            if isinstance(func, ast.Name) and func.id.startswith("re"):
+                return False
+    return True
+
+
+def check_sql_placeholders(node: ast.AST) -> bool:
+    for child in ast.walk(node):
+        if isinstance(child, ast.Call):
+            func = child.func
+            if isinstance(func, ast.Attribute) and func.attr in {"execute", "executemany"}:
+                if child.args and isinstance(child.args[0], ast.Constant) and isinstance(child.args[0].value, str):
+                    sql = child.args[0].value.lower()
+                    if re.search(r"\b(select|insert|update|delete)\b", sql) and "?" not in sql:
+                        return True
+    return False
+
+
+def scan_file(path: Path, *, correlation_id: str) -> List[Finding]:
+    path = path.resolve()
+    source = path.read_text(encoding="utf-8")
+    findings: List[Finding] = []
+    if detect_secrets(source):
+        findings.append(Finding(path, "potential secret detected"))
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        logger.warning("Failed to parse %s", path, extra={"correlation_id": correlation_id})
+        return findings
+    for node in [n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef)]:
+        if function_lacks_validation(node):
+            findings.append(Finding(path, f"function '{node.name}' lacks input validation"))
+    if check_sql_placeholders(tree):
+        findings.append(Finding(path, "SQL statement without parameter placeholders"))
+    return findings
+
+
+def scan_paths(paths: Iterable[Path], *, correlation_id: str) -> List[Finding]:
+    results: List[Finding] = []
+    for path in paths:
+        path = path.resolve()
+        if path.is_dir():
+            for file in path.rglob("*.py"):
+                results.extend(scan_file(file, correlation_id=correlation_id))
+        elif path.suffix == ".py":
+            results.extend(scan_file(path, correlation_id=correlation_id))
+    return results
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Scan Python files for security issues")
+    parser.add_argument("path", nargs="?", default=".", help="Path to scan")
+    args = parser.parse_args(argv)
+    correlation_id = str(uuid.uuid4())
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s [%(correlation_id)s] %(message)s",
+    )
+    target = Path(args.path).resolve()
+    if not target.exists():
+        logger.error("Path %s does not exist", target, extra={"correlation_id": correlation_id})
+        return 1
+    findings = scan_paths([target], correlation_id=correlation_id)
+    for finding in findings:
+        logger.error("%s: %s", finding.path, finding.message, extra={"correlation_id": correlation_id})
+    if findings:
+        logger.error("Security scan failed with %d issue(s)", len(findings), extra={"correlation_id": correlation_id})
+        return 1
+    logger.info("Security scan passed", extra={"correlation_id": correlation_id})
+    return 0
+
+
+if __name__ == "__main__":
+    import argparse
+
+    sys.exit(main())

--- a/tests/test_security_scan.py
+++ b/tests/test_security_scan.py
@@ -1,0 +1,34 @@
+import sys
+from importlib import util
+from pathlib import Path
+
+spec = util.spec_from_file_location("security_scan", Path("scripts/security_scan.py"))
+security_scan = util.module_from_spec(spec)
+assert spec and spec.loader
+sys.modules[spec.name] = security_scan
+spec.loader.exec_module(security_scan)
+
+
+def run_scan(tmp_path: Path) -> list[security_scan.Finding]:
+    return security_scan.scan_paths([tmp_path], correlation_id="test")
+
+
+def test_detects_secret(tmp_path: Path) -> None:
+    file = tmp_path / "secrets.py"
+    file.write_text("api_key = 'abcd'")
+    findings = run_scan(tmp_path)
+    assert any("secret" in f.message for f in findings)
+
+
+def test_flags_missing_input_validation(tmp_path: Path) -> None:
+    file = tmp_path / "unsafe.py"
+    file.write_text("def foo(path):\n    return open(path).read()\n")
+    findings = run_scan(tmp_path)
+    assert any("lacks input validation" in f.message for f in findings)
+
+
+def test_flags_sql_without_placeholders(tmp_path: Path) -> None:
+    file = tmp_path / "db.py"
+    file.write_text("def query(db):\n    db.execute('SELECT * FROM users')\n")
+    findings = run_scan(tmp_path)
+    assert any("SQL statement without parameter placeholders" in f.message for f in findings)


### PR DESCRIPTION
## Summary
- add `security_scan.py` to detect secrets, missing input validation, and unsafe SQL
- provide CLI for scanning paths
- document security scanner usage in README

## Testing
- `pytest -q`
- `python scripts/security_scan.py scripts`


------
https://chatgpt.com/codex/tasks/task_e_68b4de5f47d08322b95b80a9fd1de0ac