### PR TITLE
perf: incremental FTS index build

### DIFF
--- a/scripts/build_index.py
+++ b/scripts/build_index.py
@@ -1,57 +1,196 @@
-import sqlite3, json, pathlib
+"""Build the SQLite FTS5 index from JSON issue files.
+
+This script maintains a contentless FTS5 index for fast search over issue metadata. It
+tracks file modification times to update only changed records, drastically reducing
+rebuild time for large datasets. The index is optimized using FTS5 merge operations and
+an `automerge` configuration. After updates, an integrity check validates index health.
+
+Usage:
+    python scripts/build_index.py
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import time
+import uuid
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
 from json_utils import load_json
 
-ROOT = pathlib.Path('issuesdb')
-DB   = ROOT / 'issues.sqlite'
-SQL  = pathlib.Path('issues_index.sql')
 
-def iter_docs():
-    for p in (ROOT / 'issues').glob('*/*/*.json'):
-        yield load_json(p)
+ROOT = Path('issuesdb')
+DB = ROOT / 'issues.sqlite'
+SQL = Path('issues_index.sql')
+STATE = ROOT / 'index_state.json'
 
-con = sqlite3.connect(DB)
-cur = con.cursor()
-cur.executescript(SQL.read_text(encoding='utf-8'))
-cur.execute('PRAGMA journal_mode=WAL;')
 
-def upsert_issue(doc):
+def get_logger(correlation_id: str) -> logging.LoggerAdapter:
+    """Return a structured logger with correlation ID."""
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s %(levelname)s [cid=%(cid)s] %(message)s',
+    )
+    base_logger = logging.getLogger(__name__)
+    return logging.LoggerAdapter(base_logger, {'cid': correlation_id})
+
+
+def iter_issue_files() -> Iterable[Path]:
+    """Yield all JSON issue files."""
+
+    return (ROOT / 'issues').glob('*/*/*.json')
+
+
+def load_state() -> Dict[str, int]:
+    if STATE.exists():
+        return json.loads(STATE.read_text(encoding='utf-8'))
+    return {}
+
+
+def save_state(state: Dict[str, int]) -> None:
+    STATE.write_text(json.dumps(state, ensure_ascii=False, indent=2), encoding='utf-8')
+
+
+def upsert_issue(cur: sqlite3.Cursor, doc: Dict[str, object]) -> None:
     cur.execute(
-    """INSERT INTO issues(issue_id,source,source_rule_id,language,title,summary,fix_steps,
-                          severity,confidence,taxonomy_json,frequency,metadata_json,updated_at)
-       VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)
-       ON CONFLICT(issue_id) DO UPDATE SET
-         title=excluded.title, summary=excluded.summary, fix_steps=excluded.fix_steps,
-         severity=excluded.severity, confidence=excluded.confidence, frequency=excluded.frequency,
-         taxonomy_json=excluded.taxonomy_json, metadata_json=excluded.metadata_json, updated_at=excluded.updated_at
-    """,
-    (doc['issue_id'], doc['source'], doc.get('source_rule_id'), doc.get('language'),
-     doc['title'], doc.get('summary'), doc.get('fix_steps'),
-     doc.get('severity'), doc.get('confidence'),
-     json.dumps(doc.get('taxonomy', {}), ensure_ascii=False),
-     doc.get('frequency'),
-     json.dumps(doc.get('metadata', {}), ensure_ascii=False),
-     doc.get('updated_at'))
+        """
+        INSERT INTO issues(
+            issue_id,source,source_rule_id,language,title,summary,fix_steps,
+            severity,confidence,taxonomy_json,frequency,metadata_json,updated_at
+        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)
+        ON CONFLICT(issue_id) DO UPDATE SET
+            title=excluded.title,
+            summary=excluded.summary,
+            fix_steps=excluded.fix_steps,
+            severity=excluded.severity,
+            confidence=excluded.confidence,
+            frequency=excluded.frequency,
+            taxonomy_json=excluded.taxonomy_json,
+            metadata_json=excluded.metadata_json,
+            updated_at=excluded.updated_at
+        """,
+        (
+            doc['issue_id'],
+            doc['source'],
+            doc.get('source_rule_id'),
+            doc.get('language'),
+            doc['title'],
+            doc.get('summary'),
+            doc.get('fix_steps'),
+            doc.get('severity'),
+            doc.get('confidence'),
+            json.dumps(doc.get('taxonomy', {}), ensure_ascii=False),
+            doc.get('frequency'),
+            json.dumps(doc.get('metadata', {}), ensure_ascii=False),
+            doc.get('updated_at'),
+        ),
     )
     cur.execute('DELETE FROM signals WHERE issue_id=?', (doc['issue_id'],))
     for s in doc.get('signals', []):
-        cur.execute('INSERT INTO signals(issue_id,kind,value) VALUES(?,?,?)', (doc['issue_id'], s['kind'], s['value']))
+        cur.execute(
+            'INSERT INTO signals(issue_id,kind,value) VALUES(?,?,?)',
+            (doc['issue_id'], s['kind'], s['value']),
+        )
     cur.execute('DELETE FROM references_web WHERE issue_id=?', (doc['issue_id'],))
     for r in doc.get('references', []):
-        cur.execute('INSERT INTO references_web(issue_id,label,url,license) VALUES(?,?,?,?)', (doc['issue_id'], r['label'], r['url'], r.get('license')))
+        cur.execute(
+            'INSERT INTO references_web(issue_id,label,url,license) VALUES(?,?,?,?)',
+            (doc['issue_id'], r['label'], r['url'], r.get('license')),
+        )
 
-for doc in iter_docs():
-    upsert_issue(doc)
 
-# rebuild FTS content
-cur.execute('DELETE FROM fts_issues')
-cur.execute(
-    """
-    INSERT INTO fts_issues(rowid,title,summary,fix_steps,signals_concat,language)
-    SELECT rowid, title, COALESCE(summary,''), COALESCE(fix_steps,''),
-           COALESCE((SELECT TRIM(GROUP_CONCAT(value,' ')) FROM signals s WHERE s.issue_id=i.issue_id),'') AS signals_concat,
-           COALESCE(language,'')
-    FROM issues i
-    """
-)
-con.commit(); con.close()
-print(f'Built {DB}')
+def update_fts(cur: sqlite3.Cursor, issue_id: str) -> None:
+    row = cur.execute('SELECT rowid FROM issues WHERE issue_id=?', (issue_id,)).fetchone()
+    if not row:
+        return
+    cur.execute(
+        """
+        INSERT INTO fts_issues(rowid,title,summary,fix_steps,signals_concat,language)
+        SELECT rowid,
+               title,
+               COALESCE(summary,''),
+               COALESCE(fix_steps,''),
+               COALESCE((SELECT TRIM(GROUP_CONCAT(value,' '))
+                         FROM signals s WHERE s.issue_id=i.issue_id),'') AS signals_concat,
+               COALESCE(language,'')
+        FROM issues i
+        WHERE issue_id=?
+        """,
+        (issue_id,),
+    )
+
+
+def delete_issue(cur: sqlite3.Cursor, issue_id: str) -> None:
+    row = cur.execute('SELECT rowid FROM issues WHERE issue_id=?', (issue_id,)).fetchone()
+    if not row:
+        return
+    cur.execute(
+        "INSERT INTO fts_issues(fts_issues, rowid) VALUES('delete', ?)",
+        (row[0],),
+    )
+    cur.execute('DELETE FROM signals WHERE issue_id=?', (issue_id,))
+    cur.execute('DELETE FROM references_web WHERE issue_id=?', (issue_id,))
+    cur.execute('DELETE FROM issues WHERE issue_id=?', (issue_id,))
+
+
+def detect_changes(files: Iterable[Path], state: Dict[str, int]) -> Tuple[List[Path], List[str], Dict[str, int]]:
+    changed: List[Path] = []
+    new_state: Dict[str, int] = {}
+    for p in files:
+        mtime = int(p.stat().st_mtime_ns)
+        key = str(p.relative_to(ROOT))
+        new_state[key] = mtime
+        if state.get(key) != mtime:
+            changed.append(p)
+    removed = [key for key in state.keys() if key not in new_state]
+    return changed, removed, new_state
+
+
+def main() -> None:
+    cid = uuid.uuid4().hex[:8]
+    logger = get_logger(cid)
+    start = time.time()
+    state = load_state()
+
+    files = list(iter_issue_files())
+    changed, removed, new_state = detect_changes(files, state)
+    if not changed and not removed and DB.exists():
+        logger.info(f'index up-to-date seconds={round(time.time() - start, 2)}')
+        return
+
+    con = sqlite3.connect(DB)
+    cur = con.cursor()
+    cur.executescript(SQL.read_text(encoding='utf-8'))
+    cur.execute('PRAGMA journal_mode=WAL;')
+    cur.execute("INSERT INTO fts_issues(fts_issues, rank) VALUES('automerge', 4)")
+
+    for key in removed:
+        issue_id = Path(key).stem
+        delete_issue(cur, issue_id)
+
+    for path in changed:
+        doc = load_json(path)
+        upsert_issue(cur, doc)
+        update_fts(cur, doc['issue_id'])
+
+    cur.execute("INSERT INTO fts_issues(fts_issues, rank) VALUES('merge', 16)")
+    cur.execute("INSERT INTO fts_issues(fts_issues) VALUES('integrity-check')")
+    if cur.fetchall():
+        raise RuntimeError('fts_issues integrity check failed')
+
+    con.commit()
+    con.close()
+    save_state(new_state)
+    logger.info(
+        f'index build complete updated={len(changed)} removed={len(removed)} '
+        f'seconds={round(time.time() - start, 2)}'
+    )
+
+
+if __name__ == '__main__':
+    main()
+

--- a/tests/test_build_index.py
+++ b/tests/test_build_index.py
@@ -1,0 +1,60 @@
+import hashlib
+import json
+import pathlib
+import sqlite3
+import sys
+import time
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / 'scripts'))
+import build_index
+
+
+def _write_issue(dir_path: pathlib.Path, idx: int) -> str:
+    issue_id = hashlib.sha1(str(idx).encode()).hexdigest()
+    doc = {
+        'issue_id': issue_id,
+        'source': 'src',
+        'language': 'py',
+        'title': f'Issue {idx}',
+        'signals': [{'kind': 'rule', 'value': 'S1'}],
+    }
+    (dir_path / f'{issue_id}.json').write_text(json.dumps(doc), 'utf-8')
+    return issue_id
+
+
+def test_incremental_build(monkeypatch, tmp_path):
+    root = tmp_path / 'issuesdb'
+    issues_dir = root / 'issues' / 'src' / 'py'
+    issues_dir.mkdir(parents=True)
+
+    sql_path = pathlib.Path(__file__).resolve().parents[1] / 'issues_index.sql'
+    monkeypatch.setattr(build_index, 'ROOT', root)
+    monkeypatch.setattr(build_index, 'DB', root / 'issues.sqlite')
+    monkeypatch.setattr(build_index, 'SQL', sql_path)
+    monkeypatch.setattr(build_index, 'STATE', root / 'index_state.json')
+
+    for i in range(1001):
+        _write_issue(issues_dir, i)
+
+    start = time.time()
+    build_index.main()
+    full_time = time.time() - start
+
+    doc_path = next(issues_dir.iterdir())
+    doc = json.loads(doc_path.read_text('utf-8'))
+    doc['title'] = 'updated'
+    doc_path.write_text(json.dumps(doc), 'utf-8')
+
+    start = time.time()
+    build_index.main()
+    incr_time = time.time() - start
+
+    assert incr_time < full_time
+
+    con = sqlite3.connect(root / 'issues.sqlite')
+    cur = con.cursor()
+    assert cur.execute('SELECT COUNT(*) FROM issues').fetchone()[0] == 1001
+    con.close()
+


### PR DESCRIPTION
## Summary
- track file modification times and update only changed issue docs
- tune FTS5 index with automerge/merge and integrity checks
- add regression test for incremental index build performance

## Testing
- `pytest -q`
- `python scripts/build_index.py`

------
https://chatgpt.com/codex/tasks/task_e_68b4e24f95f08322a1a98aaa2b6e46c4