### PR TITLE
fix: use space-separated FTS5 prefix list

### DIFF
--- a/issues_index.sql
+++ b/issues_index.sql
@@ -35,5 +35,5 @@ USING fts5(
   title, summary, fix_steps, signals_concat, language,
   content='',
   tokenize='porter',
-  prefix='2,3,4'
+  prefix='2 3 4'
 );


### PR DESCRIPTION
## Summary
- use space-separated prefixes in FTS5 schema per ruleset

## Testing
- `python scripts/build_index.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4ef30d28483229072ac28e62f7cf2