### PR TITLE
feat: implement FTS search utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,5 +47,15 @@ The command exits with a non-zero status when issues are found so it can be used
    ├─ build_index.py
    ├─ chunk_export.py
    ├─ render_memory_bank.py
+   ├─ search.py
    └─ security_scan.py
+```
+
+## Search
+
+Use the SQLite index for simple queries:
+
+```python
+from search import search
+print(search('demo', 5))
 ```

--- a/scripts/search.py
+++ b/scripts/search.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import logging
+import sqlite3
+import time
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict, List
+
+DB = Path('issuesdb/issues.sqlite')
+logger = logging.getLogger(__name__)
+
+_metrics = {'queries': 0, 'seconds_total': 0.0}
+
+
+def _prepare_query(query: str) -> str:
+    return ' '.join(f"{term}*" for term in query.split())
+
+
+def query_fts(db_path: Path | str, query: str, limit: int) -> List[Dict[str, str]]:
+    assert limit > 0
+    if not query:
+        return []
+    fts_query = _prepare_query(query)
+    start = time.time()
+    con = sqlite3.connect(db_path)
+    try:
+        cur = con.cursor()
+        cur.execute(
+            (
+                'SELECT i.issue_id,'
+                '       i.title,'
+                '       i.summary,'
+                '       i.fix_steps,'
+                '       i.language'
+                '  FROM fts_issues'
+                '  JOIN issues AS i ON i.rowid = fts_issues.rowid'
+                ' WHERE fts_issues MATCH ?'
+                ' ORDER BY bm25(fts_issues)'
+                ' LIMIT ?'
+            ),
+            (fts_query, limit),
+        )
+        rows = [
+            {
+                'issue_id': r[0],
+                'title': r[1],
+                'summary': r[2],
+                'fix_steps': r[3],
+                'language': r[4],
+            }
+            for r in cur.fetchall()
+        ]
+    finally:
+        con.close()
+    elapsed = time.time() - start
+    _metrics['queries'] += 1
+    _metrics['seconds_total'] += elapsed
+    logger.info('search query=%s limit=%s seconds=%s', query, limit, round(elapsed, 4))
+    return rows
+
+
+@lru_cache(maxsize=128)
+def search(query: str, limit: int) -> List[Dict[str, str]]:
+    return query_fts(DB, query, limit)
+
+
+def get_metrics() -> Dict[str, float]:
+    return dict(_metrics)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,65 @@
+import sqlite3
+from pathlib import Path
+import sys
+import pathlib
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / 'scripts'))
+import search as search_module
+
+
+def create_db(tmp_path: Path) -> Path:
+    db_path = tmp_path / 'issues.sqlite'
+    con = sqlite3.connect(db_path)
+    cur = con.cursor()
+    cur.executescript(
+        '''
+        CREATE TABLE issues (
+            issue_id TEXT PRIMARY KEY,
+            title TEXT,
+            summary TEXT,
+            fix_steps TEXT,
+            language TEXT
+        );
+        CREATE VIRTUAL TABLE fts_issues USING fts5(
+            title, summary, fix_steps, signals_concat, language,
+            content=''
+        );
+        '''
+    )
+    cur.execute(
+        'INSERT INTO issues(issue_id,title,summary,fix_steps,language) VALUES (?,?,?,?,?)',
+        ('id1', 'Example rule', 'Demo summary', 'Do something', 'py'),
+    )
+    rowid = cur.execute('SELECT rowid FROM issues WHERE issue_id=?', ('id1',)).fetchone()[0]
+    cur.execute(
+        'INSERT INTO fts_issues(rowid,title,summary,fix_steps,signals_concat,language) '
+        'VALUES (?,?,?,?,?,?)',
+        (rowid, 'Example rule', 'Demo summary', 'Do something', '', 'py'),
+    )
+    con.commit()
+    con.close()
+    return db_path
+
+
+def test_query_fts_prefix_and_metrics(tmp_path: Path) -> None:
+    db = create_db(tmp_path)
+    before = search_module.get_metrics()
+    rows = search_module.query_fts(db, 'Exam', 5)
+    assert rows and rows[0]['issue_id'] == 'id1'
+    after = search_module.get_metrics()
+    assert after['queries'] == before.get('queries', 0) + 1
+
+
+def test_search_uses_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = {'n': 0}
+
+    def fake_query_fts(db_path: Path, query: str, limit: int):
+        calls['n'] += 1
+        return []
+
+    monkeypatch.setattr(search_module, 'query_fts', fake_query_fts)
+    search_module.search.cache_clear()
+    search_module.search('demo', 1)
+    search_module.search('demo', 1)
+    assert calls['n'] == 1


### PR DESCRIPTION
## Summary
- add reusable FTS search helper with cached wrapper
- expose query metrics and log execution time
- document usage and test search behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4f563b1b083228ae51eeeb2d4c6f0