### PR TITLE
feat: guard build_index with projected memory checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## [Unreleased]
+### Added
+- Warn and abort in `build_index.py` based on projected memory from issue count and batch size.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ python scripts/chunk_export.py
 python scripts/render_memory_bank.py
 ```
 
+### Memory Controls
+
+`scripts/build_index.py` estimates memory usage before indexing. It warns when
+`issues * batch_size` exceeds `--memory-warn-mb` and aborts when above
+`--memory-limit-mb`:
+
+```bash
+python scripts/build_index.py --batch-size 500 --memory-warn-mb 2000 --memory-limit-mb 4000
+```
+
 ## Security Scan
 
 Scan the repository for potential secrets, missing input validation, and unsafe SQL usage:

--- a/docs/adr/0001-memory-projection.md
+++ b/docs/adr/0001-memory-projection.md
@@ -1,0 +1,5 @@
+# ADR 0001: Pre-scan Memory Projection
+- Status: Accepted
+- Context: Large datasets can exceed memory when indexing issues.
+- Decision: Count issue files streamingly and compute projected memory as `issues * batch_size`.
+- Consequences: Warn when projection exceeds `--memory-warn-mb` and exit when above `--memory-limit-mb`.

--- a/scripts/build_index.py
+++ b/scripts/build_index.py
@@ -186,6 +186,20 @@ def main(argv: Optional[List[str]] = None) -> None:
 
     cid = uuid.uuid4().hex[:8]
     logger = get_logger(cid)
+    total_files = sum(1 for _ in iter_issue_files())
+    projected_mb = total_files * args.batch_size
+    if args.memory_limit_mb and projected_mb > args.memory_limit_mb:
+        raise SystemExit(
+            f'projected memory {projected_mb}MB exceeds limit {args.memory_limit_mb}MB'
+        )
+    if args.memory_warn_mb and projected_mb > args.memory_warn_mb:
+        logger.warning(
+            'projected memory usage projected_mb=%s warn_mb=%s',
+            projected_mb,
+            args.memory_warn_mb,
+        )
+    logger.info('total issue files=%s projected_mb=%s', total_files, projected_mb)
+
     start = time.time()
     state = load_state()
     removed_keys = set(state.keys())


### PR DESCRIPTION
## Summary
- count issue files before indexing
- warn or exit when projected memory (`issues * batch_size`) crosses thresholds
- document memory controls and add ADR

## Testing
- `python scripts/security_scan.py scripts` *(fails: 3 issues)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4fc63f9c08322b2aab00217d45e63