### PR TITLE
feat: implement database health check script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 - Warn and abort in `build_index.py` based on projected memory from issue count and batch size.
 - Require `psutil>=5.9.0` and document setup dependency.
 - Parametrized tests for batch-size and memory flags with psutil-based memory simulation.
+- `check_health.py` CLI for SQLite and FTS5 integrity validation.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ python scripts/chunk_export.py
 python scripts/render_memory_bank.py
 ```
 
+### Health Check
+
+Verify the SQLite database and FTS5 index integrity:
+
+```bash
+python scripts/check_health.py --check-health
+```
+
 ### Memory Controls
 
 `scripts/build_index.py` estimates memory usage before indexing. It warns when

--- a/docs/adr/0002-check-health.md
+++ b/docs/adr/0002-check-health.md
@@ -1,0 +1,5 @@
+# ADR 0002: Database Health Check
+- Status: Accepted
+- Context: Need a standalone way to verify SQLite and FTS5 integrity.
+- Decision: Add `scripts/check_health.py` with `--check-health` flag invoking FTS5 and `PRAGMA` checks.
+- Consequences: Enables automated detection of index or database corruption.

--- a/scripts/check_health.py
+++ b/scripts/check_health.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import argparse
+import logging
+import sqlite3
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def check_fts5_integrity(db_path: Path) -> None:
+    if not db_path.exists():
+        raise FileNotFoundError(f'{db_path} does not exist')
+    con = sqlite3.connect(db_path)
+    try:
+        cur = con.cursor()
+        try:
+            cur.execute("INSERT INTO fts_issues(fts_issues) VALUES('integrity-check')")
+            if cur.fetchall():
+                raise RuntimeError('fts_issues integrity check failed')
+            if cur.execute('PRAGMA integrity_check').fetchone()[0] != 'ok':
+                raise RuntimeError('database integrity check failed')
+        except sqlite3.DatabaseError as exc:
+            raise RuntimeError(str(exc)) from exc
+    finally:
+        con.close()
+
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--db-path', type=Path, default=Path('issuesdb/issues.sqlite'))
+    ap.add_argument('--check-health', action='store_true')
+    return ap.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    args = parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
+    if not args.check_health:
+        return
+    try:
+        check_fts5_integrity(args.db_path)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error('health check failed: %s', exc)
+        raise SystemExit(1)
+    logger.info('database health OK')
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_check_health.py
+++ b/tests/test_check_health.py
@@ -1,0 +1,44 @@
+import pathlib
+import sqlite3
+import sys
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / 'scripts'))
+import check_health
+
+
+def _init_db(db_path: pathlib.Path) -> None:
+    con = sqlite3.connect(db_path)
+    con.execute(
+        """
+        CREATE VIRTUAL TABLE fts_issues USING fts5(
+            title, summary, fix_steps, signals_concat, language,
+            content='', tokenize='porter', prefix='2 3 4'
+        )
+        """
+    )
+    con.commit()
+    con.close()
+
+
+def test_check_fts5_integrity_ok(tmp_path):
+    db = tmp_path / 'db.sqlite'
+    _init_db(db)
+    check_health.check_fts5_integrity(db)
+
+
+def test_check_fts5_integrity_corrupted(tmp_path):
+    db = tmp_path / 'db.sqlite'
+    _init_db(db)
+    con = sqlite3.connect(db)
+    cur = con.cursor()
+    cur.execute(
+        "INSERT INTO fts_issues(rowid,title,summary,fix_steps,signals_concat,language)"
+        " VALUES(1,'t','','','','')"
+    )
+    cur.execute('DROP TABLE fts_issues_data')
+    con.commit()
+    con.close()
+    with pytest.raises(RuntimeError):
+        check_health.check_fts5_integrity(db)


### PR DESCRIPTION
## Summary
- add check_health.py to validate SQLite and FTS5 integrity
- document health check and note in changelog
- cover healthy and corrupted cases with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5022ebd708322872f0190958eb4e6