### PR TITLE
feat: add metrics collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Added
+- MetricsCollector for daily JSONL metrics logging with daily rotation.
 - Warn and abort in `build_index.py` based on projected memory from issue count and batch size.
 - Require `psutil>=5.9.0` and document setup dependency.
 - Parametrized tests for batch-size and memory flags with psutil-based memory simulation.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ python scripts/security_scan.py scripts
 
 The command exits with a non-zero status when issues are found so it can be used in CI workflows.
 
+## Metrics Collector
+
+Record operational events in daily JSONL files:
+
+```python
+from monitoring.metrics_collector import MetricsCollector
+mc = MetricsCollector()
+mc.record("collect", "ok", duration_ms=120)
+```
+
+Disable with `METRICS_ENABLED=false`.
+
 ## Layout
 ```
 .

--- a/monitoring/metrics_collector.py
+++ b/monitoring/metrics_collector.py
@@ -1,0 +1,61 @@
+import json
+import os
+from datetime import datetime, date, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+class MetricsCollector:
+    """Collects simple metrics by writing JSONL files per day."""
+
+    def __init__(self, base_dir: Optional[Path] = None, *, enabled: Optional[bool] = None) -> None:
+        self.base_dir = Path(base_dir or Path('metrics') / 'daily')
+        env_enabled = os.getenv('METRICS_ENABLED', 'true').lower() != 'false'
+        self.enabled = env_enabled if enabled is None else enabled
+
+    def _get_today(self) -> date:
+        return datetime.now(timezone.utc).date()
+
+    @staticmethod
+    def _validate(event_type: str, status: str) -> None:
+        if not isinstance(event_type, str) or not event_type:
+            raise ValueError('event_type must be a non-empty string')
+        if not isinstance(status, str) or not status:
+            raise ValueError('status must be a non-empty string')
+
+    def record(
+        self,
+        event_type: str,
+        status: str,
+        *,
+        duration_ms: Optional[int] = None,
+        details: Optional[Dict[str, Any]] = None,
+        cid: Optional[str] = None,
+    ) -> None:
+        """Record a metric event.
+
+        Parameters mirror monitoring requirements. When disabled, this is a no-op.
+        """
+        if not self.enabled:
+            return
+
+        self._validate(event_type, status)
+
+        record = {
+            'ts': datetime.now(timezone.utc).isoformat(),
+            'event_type': event_type,
+            'status': status,
+        }
+        if duration_ms is not None:
+            record['duration_ms'] = duration_ms
+        if details is not None:
+            record['details'] = details
+        if cid is not None:
+            record['cid'] = cid
+
+        today = self._get_today().isoformat()
+        path = self.base_dir / f'{today}.json'
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open('a', encoding='utf-8') as fh:
+            json.dump(record, fh, ensure_ascii=False)
+            fh.write('\n')

--- a/tests/monitoring/test_metrics_collector.py
+++ b/tests/monitoring/test_metrics_collector.py
@@ -1,0 +1,47 @@
+import json
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from monitoring.metrics_collector import MetricsCollector
+
+
+def test_record_creates_daily_file(tmp_path):
+    base = tmp_path / 'metrics' / 'daily'
+    collector = MetricsCollector(base)
+    collector.record('test_event', 'ok', duration_ms=5)
+    today = collector._get_today().isoformat()
+    file_path = base / f'{today}.json'
+    assert file_path.exists()
+    content = file_path.read_text(encoding='utf-8').strip()
+    record = json.loads(content)
+    assert record['event_type'] == 'test_event'
+    assert record['status'] == 'ok'
+    assert record['duration_ms'] == 5
+
+
+def test_rotation(tmp_path):
+    base = tmp_path / 'metrics' / 'daily'
+    collector = MetricsCollector(base)
+
+    collector._get_today = lambda: date(2024, 1, 1)
+    collector.record('e1', 'ok')
+    collector._get_today = lambda: date(2024, 1, 2)
+    collector.record('e2', 'ok')
+
+    assert (base / '2024-01-01.json').exists()
+    assert (base / '2024-01-02.json').exists()
+
+
+def test_disabled(tmp_path, monkeypatch):
+    monkeypatch.setenv('METRICS_ENABLED', 'false')
+    base = tmp_path / 'metrics' / 'daily'
+    collector = MetricsCollector(base)
+    collector.record('e', 'ok')
+    assert not base.exists()
+    monkeypatch.delenv('METRICS_ENABLED', raising=False)


### PR DESCRIPTION
## Summary
- add configurable `MetricsCollector` that writes daily JSONL metric files
- allow disabling metrics via `METRICS_ENABLED=false`
- test daily rotation and opt-out behavior

## Testing
- `pytest tests/monitoring/test_metrics_collector.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b50bfd31fc8322a9f07c52bf83037a