### PR TITLE
feat: add health check metrics and alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@
 - Require `psutil>=5.9.0` and document setup dependency.
 - Parametrized tests for batch-size and memory flags with psutil-based memory simulation.
 - `check_health.py` CLI for SQLite and FTS5 integrity validation.
+- Health check metrics, alerting, and atomic status file with interval skipping.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Verify the SQLite database and FTS5 index integrity:
 python scripts/check_health.py --check-health
 ```
 
+The run writes the latest status to `metrics/health_status.json` and records a
+`check_health` metric. Set `HEALTH_CHECK_INTERVAL_MIN` to skip repeated runs.
+
 ### Memory Controls
 
 `scripts/build_index.py` estimates memory usage before indexing. It warns when

--- a/monitoring/alert_manager.py
+++ b/monitoring/alert_manager.py
@@ -1,0 +1,20 @@
+import logging
+import os
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class AlertManager:
+    """Simple alert manager writing critical events to the log."""
+
+    def __init__(self, *, enabled: Optional[bool] = None) -> None:
+        env_enabled = os.getenv('ALERTS_ENABLED', 'true').lower() != 'false'
+        self.enabled = env_enabled if enabled is None else enabled
+
+    def critical(self, message: str) -> None:
+        if not self.enabled:
+            return
+        if not isinstance(message, str) or not message:
+            raise ValueError('message must be a non-empty string')
+        logger.critical(message)

--- a/scripts/check_health.py
+++ b/scripts/check_health.py
@@ -1,12 +1,20 @@
 from __future__ import annotations
 
 import argparse
+import json
 import logging
+import os
 import sqlite3
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Optional
 
+from monitoring.alert_manager import AlertManager
+from monitoring.metrics_collector import MetricsCollector
+
 logger = logging.getLogger(__name__)
+
+HEALTH_STATUS_PATH = Path('metrics/health_status.json')
 
 
 def check_fts5_integrity(db_path: Path) -> None:
@@ -27,6 +35,25 @@ def check_fts5_integrity(db_path: Path) -> None:
         con.close()
 
 
+def _write_status(data: dict) -> None:
+    HEALTH_STATUS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp = HEALTH_STATUS_PATH.with_suffix(HEALTH_STATUS_PATH.suffix + '.tmp')
+    with tmp.open('w', encoding='utf-8') as fh:
+        json.dump(data, fh, ensure_ascii=False)
+    tmp.replace(HEALTH_STATUS_PATH)
+
+
+def _should_skip(path: Path, interval_min: int) -> bool:
+    if not path.exists():
+        return False
+    try:
+        existing = json.loads(path.read_text())
+        last = datetime.fromisoformat(existing['ts'])
+    except Exception:
+        return False
+    return datetime.now(timezone.utc) - last < timedelta(minutes=interval_min)
+
+
 def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
     ap = argparse.ArgumentParser()
     ap.add_argument('--db-path', type=Path, default=Path('issuesdb/issues.sqlite'))
@@ -39,11 +66,34 @@ def main(argv: Optional[list[str]] = None) -> None:
     logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
     if not args.check_health:
         return
+
+    metrics = MetricsCollector()
+    alerts = AlertManager()
+    interval_min = int(os.getenv('HEALTH_CHECK_INTERVAL_MIN', '0'))
+    if interval_min > 0 and _should_skip(HEALTH_STATUS_PATH, interval_min):
+        data = {'ts': datetime.now(timezone.utc).isoformat(), 'status': 'skipped'}
+        _write_status(data)
+        metrics.record('check_health', 'skipped')
+        logger.info('health check skipped')
+        return
+
     try:
         check_fts5_integrity(args.db_path)
     except Exception as exc:  # pragma: no cover - defensive
+        metrics.record('check_health', 'failure', details={'error': str(exc)})
+        alerts.critical(f'health check failed: {exc}')
+        data = {
+            'ts': datetime.now(timezone.utc).isoformat(),
+            'status': 'error',
+            'message': str(exc),
+        }
+        _write_status(data)
         logger.error('health check failed: %s', exc)
         raise SystemExit(1)
+
+    metrics.record('check_health', 'success')
+    data = {'ts': datetime.now(timezone.utc).isoformat(), 'status': 'ok'}
+    _write_status(data)
     logger.info('database health OK')
 
 


### PR DESCRIPTION
## Summary
- track check health outcomes via MetricsCollector and alert on failure
- atomically persist health status and skip checks based on interval
- cover healthy and corrupted index cases with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5120fe47c8322858a2a8b3b8a7a38