### PR TITLE
feat: add configurable alert manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@
 - Parametrized tests for batch-size and memory flags with psutil-based memory simulation.
 - `check_health.py` CLI for SQLite and FTS5 integrity validation.
 - Health check metrics, alerting, and atomic status file with interval skipping.
+- AlertManager writes active alerts to `alerts/active_alerts.json` with configurable thresholds.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,19 @@ mc.record("collect", "ok", duration_ms=120)
 
 Disable with `METRICS_ENABLED=false`.
 
+## Alert Manager
+
+Evaluate metrics and write active alerts to `alerts/active_alerts.json`:
+
+```python
+from monitoring.alert_manager import AlertManager, load_thresholds, parse_args
+thresholds = load_thresholds(parse_args([]))
+manager = AlertManager(thresholds)
+manager.check({"collection_success_rate": 0.9})
+```
+
+CLI flags or environment variables override defaults in `monitoring/config/thresholds.json`.
+
 ## Layout
 ```
 .

--- a/monitoring/alert_manager.py
+++ b/monitoring/alert_manager.py
@@ -1,20 +1,171 @@
-import logging
-import os
-from typing import Optional
+"""Alert manager evaluating metrics against thresholds and writing active alerts."""
 
-logger = logging.getLogger(__name__)
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class Alert:
+    """Represents a single alert."""
+
+    name: str
+    message: str
+    severity: str
 
 
 class AlertManager:
-    """Simple alert manager writing critical events to the log."""
+    """Evaluates metrics and writes active alerts to a JSON file."""
 
-    def __init__(self, *, enabled: Optional[bool] = None) -> None:
-        env_enabled = os.getenv('ALERTS_ENABLED', 'true').lower() != 'false'
-        self.enabled = env_enabled if enabled is None else enabled
+    def __init__(
+        self,
+        thresholds: Optional[Dict[str, float]] = None,
+        *,
+        output_path: Optional[Path] = None,
+    ) -> None:
+        if thresholds is None:
+            thresholds = load_thresholds(parse_args([]))
+        self.thresholds = thresholds
+        self.output_path = output_path or Path("alerts") / "active_alerts.json"
+
+    def evaluate(self, metrics: Dict[str, Any]) -> List[Alert]:
+        """Return alerts for metrics breaching thresholds."""
+        t = self.thresholds
+        alerts: List[Alert] = []
+
+        rate = metrics.get("collection_success_rate")
+        if rate is not None and rate < t["collection_success_rate"]:
+            alerts.append(
+                Alert(
+                    "collection_success_rate",
+                    "Collection success rate below threshold",
+                    "ERROR",
+                )
+            )
+
+        build_time = metrics.get("index_build_time_seconds")
+        if build_time is not None and build_time > t["index_build_time_seconds"]:
+            alerts.append(
+                Alert(
+                    "index_build_time_seconds",
+                    "Index build time exceeds threshold",
+                    "WARN",
+                )
+            )
+
+        disk_usage = metrics.get("disk_usage")
+        if disk_usage is not None:
+            if disk_usage > t["disk_usage_critical"]:
+                alerts.append(
+                    Alert(
+                        "disk_usage",
+                        "Disk usage above critical threshold",
+                        "CRITICAL",
+                    )
+                )
+            elif disk_usage > t["disk_usage_warn"]:
+                alerts.append(
+                    Alert(
+                        "disk_usage",
+                        "Disk usage above warning threshold",
+                        "WARN",
+                    )
+                )
+
+        mem = metrics.get("memory_usage_mb")
+        if mem is not None and mem > t["memory_usage_mb"]:
+            alerts.append(
+                Alert(
+                    "memory_usage_mb",
+                    "Memory usage above threshold",
+                    "WARN",
+                )
+            )
+
+        rate_limited = metrics.get("api_rate_limited_ratio")
+        if rate_limited is not None and rate_limited > t["api_rate_limited_ratio"]:
+            alerts.append(
+                Alert(
+                    "api_rate_limited_ratio",
+                    "API rate-limited requests ratio too high",
+                    "WARN",
+                )
+            )
+
+        fts5_ok = metrics.get("fts5_integrity_ok", True)
+        if not fts5_ok:
+            alerts.append(
+                Alert(
+                    "fts5_integrity",
+                    "FTS5 integrity check failed",
+                    "CRITICAL",
+                )
+            )
+
+        return alerts
+
+    def write_alerts(self, alerts: List[Alert]) -> None:
+        """Write alerts to the configured output file."""
+        self.output_path.parent.mkdir(parents=True, exist_ok=True)
+        data = [asdict(a) for a in alerts]
+        with self.output_path.open("w", encoding="utf-8") as fh:
+            json.dump(data, fh, ensure_ascii=False, indent=2)
 
     def critical(self, message: str) -> None:
-        if not self.enabled:
-            return
+        """Write a single critical alert with the given message."""
         if not isinstance(message, str) or not message:
-            raise ValueError('message must be a non-empty string')
-        logger.critical(message)
+            raise ValueError("message must be a non-empty string")
+        self.write_alerts([Alert("manual", message, "CRITICAL")])
+
+    def check(self, metrics: Dict[str, Any]) -> List[Alert]:
+        """Evaluate metrics and persist active alerts."""
+        alerts = self.evaluate(metrics)
+        self.write_alerts(alerts)
+        return alerts
+
+
+def load_thresholds(
+    args: argparse.Namespace,
+    config_path: Path = Path(__file__).resolve().parent / "config" / "thresholds.json",
+) -> Dict[str, float]:
+    """Load thresholds with env and CLI overrides."""
+    with config_path.open("r", encoding="utf-8") as fh:
+        thresholds: Dict[str, float] = json.load(fh)
+    for key, value in list(thresholds.items()):
+        env_val = os.getenv(f"ALERT_{key.upper()}")
+        if env_val is not None:
+            thresholds[key] = type(value)(env_val)
+        cli_val = getattr(args, key, None)
+        if cli_val is not None:
+            thresholds[key] = cli_val
+    return thresholds
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    """Parse CLI arguments for threshold overrides."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--collection-success-rate", type=float)
+    parser.add_argument("--index-build-time-seconds", type=float)
+    parser.add_argument("--disk-usage-warn", type=float)
+    parser.add_argument("--disk-usage-critical", type=float)
+    parser.add_argument("--memory-usage-mb", type=float)
+    parser.add_argument("--api-rate-limited-ratio", type=float)
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """Entry point parsing flags and writing alerts for provided metrics."""
+    args = parse_args(argv)
+    thresholds = load_thresholds(args)
+    manager = AlertManager(thresholds)
+    manager.check({})
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/monitoring/config/thresholds.json
+++ b/monitoring/config/thresholds.json
@@ -1,0 +1,8 @@
+{
+  "collection_success_rate": 0.95,
+  "index_build_time_seconds": 60,
+  "disk_usage_warn": 0.8,
+  "disk_usage_critical": 0.95,
+  "memory_usage_mb": 400,
+  "api_rate_limited_ratio": 0.1
+}

--- a/tests/monitoring/test_alert_manager.py
+++ b/tests/monitoring/test_alert_manager.py
@@ -1,0 +1,76 @@
+import json
+import pathlib
+import sys
+from pathlib import Path
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+
+from monitoring.alert_manager import AlertManager, load_thresholds, parse_args
+
+
+def make_manager(tmp_path: Path) -> tuple[AlertManager, Path]:
+    args = parse_args([])
+    thresholds = load_thresholds(args)
+    out = tmp_path / "alerts" / "active_alerts.json"
+    manager = AlertManager(thresholds, output_path=out)
+    return manager, out
+
+
+def load_file(path: Path) -> list[dict]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_collection_success_rate_breach(tmp_path):
+    manager, out = make_manager(tmp_path)
+    alerts = manager.check({"collection_success_rate": 0.9})
+    assert alerts[0].severity == "ERROR"
+    data = load_file(out)
+    assert data[0]["name"] == "collection_success_rate"
+
+
+def test_index_build_time_breach(tmp_path):
+    manager, out = make_manager(tmp_path)
+    alerts = manager.check({"index_build_time_seconds": 120})
+    assert alerts[0].severity == "WARN"
+    data = load_file(out)
+    assert data[0]["name"] == "index_build_time_seconds"
+
+
+def test_disk_usage_warn(tmp_path):
+    manager, out = make_manager(tmp_path)
+    alerts = manager.check({"disk_usage": 0.85})
+    assert alerts[0].severity == "WARN"
+    data = load_file(out)
+    assert data[0]["name"] == "disk_usage"
+
+
+def test_disk_usage_critical(tmp_path):
+    manager, out = make_manager(tmp_path)
+    alerts = manager.check({"disk_usage": 0.97})
+    assert alerts[0].severity == "CRITICAL"
+    data = load_file(out)
+    assert data[0]["severity"] == "CRITICAL"
+
+
+def test_memory_usage_breach(tmp_path):
+    manager, out = make_manager(tmp_path)
+    alerts = manager.check({"memory_usage_mb": 500})
+    assert alerts[0].severity == "WARN"
+    data = load_file(out)
+    assert data[0]["name"] == "memory_usage_mb"
+
+
+def test_api_rate_limited_breach(tmp_path):
+    manager, out = make_manager(tmp_path)
+    alerts = manager.check({"api_rate_limited_ratio": 0.2})
+    assert alerts[0].severity == "WARN"
+    data = load_file(out)
+    assert data[0]["name"] == "api_rate_limited_ratio"
+
+
+def test_fts5_integrity_failure(tmp_path):
+    manager, out = make_manager(tmp_path)
+    alerts = manager.check({"fts5_integrity_ok": False})
+    assert alerts[0].severity == "CRITICAL"
+    data = load_file(out)
+    assert data[0]["name"] == "fts5_integrity"


### PR DESCRIPTION
## Summary
- add AlertManager evaluating metrics and writing active alerts
- support threshold overrides via config, env vars, and CLI flags
- test alert generation for metric breaches

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b59601fe78832297f9de5f97624408